### PR TITLE
Remove sidebar height limit

### DIFF
--- a/view.php
+++ b/view.php
@@ -71,7 +71,7 @@
 <div id="wrapper">
     <div id="sidebar-wrapper">
             <h3>Feeds</h3>
-            <div style="height:650px; overflow-y: scroll; overflow-x: hidden; background-color:#f3f3f3; width:250px">
+            <div style="overflow-y: scroll; overflow-x: hidden; background-color:#f3f3f3; width:250px">
                 <table class="table">
                     <colgroup>
                        <col span="1" style="width: 70%;">


### PR DESCRIPTION
When viewing a large number of feeds, or at lower resolutions, the sidebar feed list does not scroll down to the bottom of the list, and is curtailed by the 650px limit.
See https://openenergymonitor.org/emon/node/12388#comment-40627
Tested on Chrome, Firefox & IE