### PR TITLE
adjusted tooltip zindex in graph.css

### DIFF
--- a/graph.css
+++ b/graph.css
@@ -119,3 +119,6 @@ input.feed-tag-checkbox{
 input.feed-tag-checkbox-left, input.feed-tag-checkbox-right{
     margin:0 5px;
 }
+#tooltip {
+    z-index: 1001;
+}


### PR DESCRIPTION
tooltip now overlays right sidebar

![image](https://user-images.githubusercontent.com/1466013/51171307-7e0f1200-18a8-11e9-99dd-be2661bc01cd.png)
