### PR TITLE
coloured label and axis

### DIFF
--- a/graph.css
+++ b/graph.css
@@ -122,3 +122,10 @@ input.feed-tag-checkbox-left, input.feed-tag-checkbox-right{
 #tooltip {
     z-index: 1001;
 }
+
+/* Multi Axes label colours */
+.legendLabel .label-left,
+.flot-y1-axis .flot-tick-label{color: #3a87ad}
+
+.legendLabel .label-right,
+.flot-y2-axis .flot-tick-label{color: #b94a48}

--- a/graph.js
+++ b/graph.js
@@ -642,7 +642,24 @@ function graph_draw()
 		    } ],
         grid: {hoverable: true, clickable: true},
         selection: { mode: "x" },
-        legend: { show: false, position: "nw", toggle: true },
+        legend: { 
+            show: false,
+            position: "nw",
+            toggle: true,
+            labelFormatter: function(label, item){
+                // text = '[←]' + label;
+                text = label;
+                cssClass = 'label-left';
+                title = 'Left Axis';
+                
+                if (item.isRight) {
+                    text = label + ' [→]';
+                    cssClass = 'label-right';
+                    title = 'Right Axis';
+                }
+                return '<span class="' + cssClass + '" title="'+title+'">' + text +'</span>'
+            },
+        },
         toggle: { scale: "visible" },
         touch: { pan: "x", scale: "x" }
     }
@@ -685,7 +702,7 @@ function graph_draw()
         
         if (feedlist[z].plottype=="lines") { plot.lines = { show: true, fill: (feedlist[z].fill ? (stacked ? 1.0 : 0.5) : 0.0), fill: feedlist[z].fill } };
         if (feedlist[z].plottype=="bars") { plot.bars = { align: "center", fill: (feedlist[z].fill ? (stacked ? 1.0 : 0.5) : 0.0), show: true, barWidth: view.interval * 1000 * 0.75 } };
-
+        plot.isRight = feedlist[z].yaxis === 2;
         plotdata.push(plot);
     }
     $.plot($('#placeholder'), plotdata, options);


### PR DESCRIPTION
fix issue #9 

still not able to separate the legend to left and right using the flot.js api.

![delwedd](https://user-images.githubusercontent.com/1466013/51603809-c068cc80-1f02-11e9-887c-fc700c48847f.png)

thanks @pb66 for the colouring suggestion... let me know your thoughts on the screenshot above


If this is still not suitable I could look at separating the legend from the flot.js `<canvas>` and running some scripting over it to separate it into two legends...

the `container` legend property allows you to render the legend outside the flot.js drawing area:
https://github.com/flot/flot/blob/master/API.md#customizing-the-legend