### PR TITLE
made the stats and options tabs format the title the same

### DIFF
--- a/graph.js
+++ b/graph.js
@@ -882,7 +882,7 @@ function graph_draw()
             }
             out += "</td>";
 
-            out += "<td>"+feedlist[z].id+":"+feedlist[z].tag+":"+feedlist[z].name + getFeedUnit(feedlist[z].id)+"</td>";
+            out += "<td>"+getFeedName(feedlist[z])+"</td>";
             out += "<td><select class='plottype' feedid="+feedlist[z].id+" style='width:80px'>";
 
             var selected = "";
@@ -910,7 +910,8 @@ function graph_draw()
         var out = "";
         for (var z in feedlist) {
             out += "<tr>";
-            out += "<td>"+feedlist[z].id+":"+feedlist[z].tag+": "+feedlist[z].name+"</td>";
+            out += "<td></td>";
+            out += "<td>"+getFeedName(feedlist[z])+"</td>";
             var quality = Math.round(100 * (1-(feedlist[z].stats.npointsnull/feedlist[z].stats.npoints)));
             out += "<td>"+quality+"% ("+(feedlist[z].stats.npoints-feedlist[z].stats.npointsnull)+"/"+feedlist[z].stats.npoints+")</td>";
             var dp = feedlist[z].dp;
@@ -943,7 +944,22 @@ function graph_draw()
         if (showcsv) printcsv();
     }
 }
+function getFeedName(item) {
+    var values = [];
+    if (typeof item !== 'object') {
+        return item;
+    }
+    if(item.hasOwnProperty('id') && item.hasOwnProperty('tag') && item.hasOwnProperty('name')) {
+        values.push(item.id);
+        values.push(item.tag);
+        values.push(item.name);
+    }
+    var name = values.join(':');
 
+    name += ' (' + getFeedUnit(item.id) + ')';
+
+    return name;
+}
 function getfeed(id) 
 {
     for (var z in feeds) {

--- a/view.php
+++ b/view.php
@@ -200,6 +200,7 @@
                     
                     <table id="feed-stats-table" class="table hide">
                         <tr>
+                            <th></th>
                             <th><?php echo _('Feed') ?></th>
                             <th><?php echo _('Quality') ?></th>
                             <th><?php echo _('Min') ?></th>


### PR DESCRIPTION
fix #65 

now uses this format for both the stats and options tabs [id]:[tag]:[name] ([unit]) 

![delwedd](https://user-images.githubusercontent.com/1466013/54592508-73960380-4a24-11e9-9a0b-58d5c27ae835.png)
