### PR TITLE
created custom collapse of 'my graphs' 

### DIFF
--- a/view.php
+++ b/view.php
@@ -409,6 +409,14 @@
             event.target.querySelector('.caret').classList.toggle('open');
             $('#tables').collapse('toggle');
         })
+
+        $('#mygraphs [data-toggle="sidebar-collapse"]').on('click', function(event){
+            event.preventDefault();
+            var trigger = $(event.target)
+            var target = $(trigger.data('target'))
+            trigger.toggleClass('collapsed')
+            target.toggleClass('in')
+        })
     });
 
     <?php


### PR DESCRIPTION
current bootstrap version broken. when collapsed or expanded it broke the ability to navigate from the graph module back to the emoncms setup menu.

![delwedd](https://user-images.githubusercontent.com/1466013/63339004-d70dbf80-c33b-11e9-8de1-3061f14ab46b.png)
