### PR TITLE
Fix yaxis2 configuration when graphs are embedded.

### DIFF
--- a/embed.php
+++ b/embed.php
@@ -135,6 +135,8 @@
             floatingtime = result.floatingtime,
             yaxismin = result.yaxismin;
             yaxismax = result.yaxismax;
+            yaxismin2 = result.yaxismin2;
+            yaxismax2 = result.yaxismax2;
             feedlist = result.feedlist;
             
             // show settings


### PR DESCRIPTION
Currently graphs when embedded ignore the min and max configuration for the right hand y axis. This change passes the yaxismin2 and yaxismax2 in the embed.php so embedded graphs display the right hand axis properly.