### PR TITLE
Refresh the graph every minute when embedded in a dashboard

### DIFF
--- a/embed.php
+++ b/embed.php
@@ -139,6 +139,10 @@
             yaxismax2 = result.yaxismax2;
             feedlist = result.feedlist;
             
+            // attempt to update time selector to match the view
+            var hours = Math.round((view.end - view.start) / 3600 / 1000);
+            $('.graph_time').val(hours);
+            
             // show settings
             showmissing = result.showmissing;
             showtag = result.showtag;
@@ -163,6 +167,16 @@
             datetimepickerInit();
             graph_resize();
             graph_reload();
+            
+            // automatic refresh
+            window.setInterval(function() {
+              if (floatingtime) {
+                $('.graph_time_refresh').click();
+              }
+              else {
+                graph_reload();
+              }
+            }, 60000);
         }
     });
     


### PR DESCRIPTION
I've been running this locally for several months, and find it exceedingly useful as it means I can keep a couple dashboards open and they're always up-to-date.

**Bonus:** it also attempts to update time selector to match the saved period instead of the default of "1 week", which always bugged me.