### PR TITLE
Add "Steps" type to graph for feeds that record discrete values

### DIFF
--- a/embed.php
+++ b/embed.php
@@ -109,6 +109,7 @@
         $lang['Lines'] = _('Lines');
         $lang['Bars'] = _('Bars');
         $lang['Points'] = _('Points');
+        $lang['Steps'] = _('Steps');
         $lang['Histogram'] = _('Histogram');
         $lang['Move up'] = _('Move up');
         $lang['Move down'] = _('Move down');

--- a/graph.js
+++ b/graph.js
@@ -847,6 +847,7 @@ function onClickLegendLink(event) {
         case 'lines': current_data[index].lines.show = !current_data[index].lines.show; break;
         case 'bars': current_data[index].bars.show = !current_data[index].bars.show; break;
         case 'points': current_data[index].points.show = !current_data[index].points.show; break;
+        case 'steps': current_data[index].steps.show = !current_data[index].steps.show; break;
     }
     plot_statistics.setData(current_data);
     // re-draw
@@ -952,6 +953,7 @@ function graph_draw()
         if (feedlist[z].plottype=="lines") { plot.lines = { show: true, fill: (feedlist[z].fill ? (stacked ? 1.0 : 0.5) : 0.0), fill: feedlist[z].fill } };
         if (feedlist[z].plottype=="bars") { plot.bars = { align: "center", fill: (feedlist[z].fill ? (stacked ? 1.0 : 0.5) : 0.0), show: true, barWidth: view.interval * 1000 * 0.75 } };
         if (feedlist[z].plottype == 'points') plot.points = {show: true, radius: 3};
+        if (feedlist[z].plottype=="steps") { plot.lines = { steps: true, show: true, fill: (feedlist[z].fill ? (stacked ? 1.0 : 0.5) : 0.0), fill: feedlist[z].fill } };
         plot.isRight = feedlist[z].yaxis === 2;
         plot.id = feedlist[z].id;
         plot.index = z;
@@ -996,6 +998,8 @@ function graph_draw()
             out += "<option value='bars' "+selected+">"+_lang['Bars']+"</option>";
             if (feedlist[z].plottype == "points") selected = "selected"; else selected = "";
             out += "<option value='points' "+selected+">"+_lang['Points']+"</option>";
+            if (feedlist[z].plottype == "steps") selected = "selected"; else selected = "";
+            out += "<option value='steps' "+selected+">"+_lang['Steps']+"</option>";
             out += "</select></td>";
             out += "<td><input class='linecolor' feedid="+feedlist[z].id+" style='width:50px' type='color' value='#"+default_linecolor+"'></td>";
             out += "<td><input class='fill' type='checkbox' feedid="+feedlist[z].id+"></td>";

--- a/view.php
+++ b/view.php
@@ -291,6 +291,7 @@
         $lang['Lines'] = _('Lines');
         $lang['Bars'] = _('Bars');
         $lang['Points'] = _('Points');
+        $lang['Steps'] = _('Steps');
         $lang['Histogram'] = _('Histogram');
         $lang['Move up'] = _('Move up');
         $lang['Move down'] = _('Move down');


### PR DESCRIPTION
For certain kinds of data, such as the state of a valve or price of electricity, plotting with a diagonal line between values doesn't really fit. It would be much nicer to plot them as Steps, such that there's a vertical line up or down for each measured value, and a horizontal line in between. Especially for feeds with higher intervals, e.g. 30 minutes.

Was requested on the forum here: [Graphing Showing “Step” data for PHPTIMESERIES Feeds](https://community.openenergymonitor.org/t/graphing-showing-step-data-for-phptimeseries-feeds/22959)

**Example A**: status of 3 pumps (separated by offsets)

![image](https://github.com/emoncms/graph/assets/75039652/fa319fda-d0bb-497e-9791-8e9415a90b80)

**Example B**: Cosy Octopus tariff and Import kWh (delta)

![image](https://github.com/emoncms/graph/assets/75039652/2c07615e-e70f-4e1f-a23c-952a8874dd68)

![image](https://github.com/emoncms/graph/assets/75039652/cd003b3a-e394-4de3-b235-daaeeb5c0fcc)


Adding this to the Graph module is very simple, basically cloning the "Lines" type and adding `steps: true` to the plot.